### PR TITLE
Add shellcheck for linting sh files

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+
+name: Shellcheck
+jobs:
+  lint:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Compatibility Server Shellcheck
+        uses: azohra/shell-linter@latest
+        with:
+          path: "amp-compatibility-server/scripts"
+          severity: "error"
+      - name: Run Dummy Data Script Shellcheck
+        uses: azohra/shell-linter@latest
+        with:
+          path: "amp-wp-dummy-data-generator/data"
+          severity: "warning"


### PR DESCRIPTION
Adding shellcheck to check for issues in shell scripts written in the project. 
This is specifically aimed to check and catch errors in PRs containing [`pre.sh`](https://github.com/rtCamp/amp-compatibility/tree/main/amp-wp-dummy-data-generator/data#file-presh) and [`post.sh`](https://github.com/rtCamp/amp-compatibility/tree/main/amp-wp-dummy-data-generator/data#file-postsh) files of dummy data generator.