### PR TITLE
Fix command deleting older versions of GAE

### DIFF
--- a/.github/workflows/gcloud-deploy.yml
+++ b/.github/workflows/gcloud-deploy.yml
@@ -70,7 +70,7 @@ jobs:
              | sed 1,5d
           )
           [[ -n "$OLD_VERSIONS" ]] \
-            && gcloud app versions delete --quiet "$OLD_VERSIONS" \
+            && gcloud app versions delete --quiet $OLD_VERSIONS \
             || echo 'No old versions to delete. Less than 5 latest versions present.'
 
     - name: Cleanup


### PR DESCRIPTION
The variable `$OLD_VERSIONS` with the quotes was becoming a single string containing multiple version numbers. Leading to no matching version found error. With the quotes removed, this is now independent version strings separated by space that work in the command to delete.